### PR TITLE
Fix cron job not installed when server has no existing crontab

### DIFF
--- a/setup-pldb.sh
+++ b/setup-pldb.sh
@@ -292,7 +292,7 @@ echo "    Update script installed at /root/pldb-update.sh"
 
 # Install weekly cron job (Monday 09:00 UTC)
 echo ">>> Installing weekly cron job..."
-( crontab -l 2>/dev/null | grep -v 'pldb-update'; echo '0 9 * * 1 /root/pldb-update.sh >> /root/pldb-update.log 2>&1' ) | crontab -
+( crontab -l 2>/dev/null | grep -v 'pldb-update' || true; echo '0 9 * * 1 /root/pldb-update.sh >> /root/pldb-update.log 2>&1' ) | crontab -
 echo "    Cron job installed: runs every Monday at 09:00 UTC"
 
 ENDSSH


### PR DESCRIPTION
## Summary
- `setup-pldb.sh` runs inside a heredoc with `set -e`. When the server has no existing crontab, `crontab -l` exits 1 and `grep -v` gets empty input and also exits 1, causing the subshell to abort before the `echo` runs. `crontab -` then receives empty stdin and installs nothing.
- Fix: add `|| true` after `grep -v 'pldb-update'` so the subshell never exits early regardless of whether a crontab exists.

## Test plan
- Confirmed the bug on the live server (159.65.99.188): crontab was empty despite setup having been run
- Manually installed the cron job and ran `/root/pldb-update.sh` — update succeeded and live site now shows TIOBE data fetched 2026-05-25

🤖 Generated with [Claude Code](https://claude.com/claude-code)